### PR TITLE
chore(scripts): update groovy scripts to work with nexus >= 3.21

### DIFF
--- a/files/groovy/create_repos_from_list.groovy
+++ b/files/groovy/create_repos_from_list.groovy
@@ -10,6 +10,30 @@ scriptResults.put('action_details', actionDetails)
 
 repositoryManager = repository.repositoryManager
 
+private Configuration newConfiguration(Map map) {
+    Configuration config
+    try {
+        config = repositoryManager.newConfiguration()
+    } catch (MissingMethodException) {
+        // Compatibility with nexus versions older than 3.21
+        config = Configuration.newInstance()
+    }
+    config.with {
+        repositoryName = map.repositoryName
+        recipeName = map.recipeName
+        online = map.online
+        attributes = map.attributes as Map
+    }
+    return config
+}
+
+private boolean configurationChanged(Configuration oldConfig, Configuration newConfig) {
+    if (oldConfig.attributes.httpclient)
+        if (oldConfig.attributes.httpclient.authentication == [:])
+            oldConfig.attributes.httpclient.authentication = null
+    return oldConfig.properties == newConfig.properties
+}
+
 parsed_args.each { currentRepo ->
 
     Map<String, String> currentResult = [name: currentRepo.name, format: currentRepo.format, type: currentRepo.type]
@@ -22,7 +46,7 @@ parsed_args.each { currentRepo ->
         if (existingRepository == null) {
             log.info('Creating configuration for new repo {} (Format: {},  Type: {})', currentRepo.name, currentRepo.format, currentRepo.type)
             // Default and/or immutable values
-            configuration = new Configuration(
+            configuration = newConfiguration(
                     repositoryName: currentRepo.name,
                     recipeName: recipeName,
                     online: true,
@@ -61,6 +85,23 @@ parsed_args.each { currentRepo ->
             ]
         }
 
+        // Configs for apt repos
+        if (currentRepo.type == 'proxy' && currentRepo.format == 'apt') {
+            configuration.attributes['apt'] = [
+                    distribution: currentRepo.distribution,
+                    flat        : Boolean.valueOf(currentRepo.flat)
+            ]
+        }
+        if (currentRepo.type == 'hosted' && currentRepo.format == 'apt') {
+            configuration.attributes['apt'] = [
+                    distribution: currentRepo.distribution
+            ]
+            configuration.attributes['aptSigning'] = [
+                    keypair   : currentRepo.keypair,
+                    passphrase: currentRepo.passphrase
+            ]
+        }
+
         // Configs for all proxy repos
         if (currentRepo.type == 'proxy') {
             authentication = currentRepo.remote_username == null ? null : [
@@ -90,11 +131,24 @@ parsed_args.each { currentRepo ->
             ]
         }
 
+        // Configure cleanup policy
+        if (currentRepo.type == 'proxy' || currentRepo.type == 'hosted') {
+            def cleanupPolicies = currentRepo.cleanup_policies as Set
+            if (cleanupPolicies != null)
+            {
+                configuration.attributes['cleanup'] = [
+                    policyName: cleanupPolicies
+                ]
+            }
+        }
+
         // Configs for docker proxy repos
         if (currentRepo.type == 'proxy' && currentRepo.format == 'docker') {
             configuration.attributes['dockerProxy'] = [
                     indexType                  : currentRepo.index_type,
-                    useTrustStoreForIndexAccess: currentRepo.use_nexus_certificates_to_access_index
+                    useTrustStoreForIndexAccess: currentRepo.use_nexus_certificates_to_access_index,
+                    foreignLayerUrlWhitelist   : currentRepo.foreign_layer_url_whitelist,
+                    cacheForeignLayers         : currentRepo.cache_foreign_layers
             ]
         }
 
@@ -121,7 +175,7 @@ parsed_args.each { currentRepo ->
             scriptResults['changed'] = true
             log.info('Configuration for repo {} created', currentRepo.name)
         } else {
-            if (!(configuration.properties == existingRepository.configuration.properties)) {
+            if (!configurationChanged(existingRepository.configuration, configuration)) {
                 repositoryManager.update(configuration)
                 currentResult.put('status', 'updated')
                 log.info('Configuration for repo {} saved', currentRepo.name)

--- a/files/groovy/setup_email.groovy
+++ b/files/groovy/setup_email.groovy
@@ -1,24 +1,25 @@
 import groovy.json.JsonSlurper
-import org.sonatype.nexus.email.EmailConfiguration
 import org.sonatype.nexus.email.EmailManager
 
 parsed_args = new JsonSlurper().parseText(args)
 
-def emailMgr = container.lookup(EmailManager.class.getName());
+def emailMgr = container.lookup(EmailManager.class.getName())
 
-emailConfig = new EmailConfiguration(
-        enabled: parsed_args.email_server_enabled,
-        host: parsed_args.email_server_host,
-        port: Integer.valueOf(parsed_args.email_server_port),
-        username: parsed_args.email_server_username,
-        password: parsed_args.email_server_password,
-        fromAddress: parsed_args.email_from_address,
-        subjectPrefix: parsed_args.email_subject_prefix,
-        startTlsEnabled: parsed_args.email_tls_enabled,
-        startTlsRequired: parsed_args.email_tls_required,
-        sslOnConnectEnabled: parsed_args.email_ssl_on_connect_enabled,
-        sslCheckServerIdentityEnabled: parsed_args.email_ssl_check_server_identity_enabled,
-        nexusTrustStoreEnabled: parsed_args.email_trust_store_enabled
-)
+def config = emailMgr.getConfiguration()
 
-emailMgr.configuration = emailConfig
+config.with {
+        enabled = parsed_args.email_server_enabled
+        host = parsed_args.email_server_host
+        port = Integer.valueOf(parsed_args.email_server_port)
+        username = parsed_args.email_server_username
+        password = parsed_args.email_server_password
+        fromAddress = parsed_args.email_from_address
+        subjectPrefix = parsed_args.email_subject_prefix
+        startTlsEnabled = parsed_args.email_tls_enabled
+        startTlsRequired = parsed_args.email_tls_required
+        sslOnConnectEnabled = parsed_args.email_ssl_on_connect_enabled
+        sslCheckServerIdentityEnabled = parsed_args.email_ssl_check_server_identity_enabled
+        nexusTrustStoreEnabled = parsed_args.email_trust_store_enabled
+}
+
+emailMgr.setConfiguration(config)

--- a/files/groovy/setup_ldap.groovy
+++ b/files/groovy/setup_ldap.groovy
@@ -1,27 +1,25 @@
 
 import org.sonatype.nexus.ldap.persist.LdapConfigurationManager
-import org.sonatype.nexus.ldap.persist.entity.LdapConfiguration
 import org.sonatype.nexus.ldap.persist.entity.Connection
 import org.sonatype.nexus.ldap.persist.entity.Mapping
 import groovy.json.JsonSlurper
 
 parsed_args = new JsonSlurper().parseText(args)
 
+def ldapConfigMgr = container.lookup(LdapConfigurationManager.class.getName())
 
-def ldapConfigMgr = container.lookup(LdapConfigurationManager.class.getName());
+// Create a new configuration with the given name
+def ldapConfig = ldapConfigMgr.newConfiguration()
+ldapConfig.setName(parsed_args.name)
 
-def ldapConfig = new LdapConfiguration()
+// Look for existing config to update and replace the blank one created earlier if found
 boolean update = false;
-
-// Look for existing config to update
 ldapConfigMgr.listLdapServerConfigurations().each {
     if (it.name == parsed_args.name) {
         ldapConfig = it
         update = true
     }
 }
-
-ldapConfig.setName(parsed_args.name)
 
 // Connection
 connection = new Connection()
@@ -68,7 +66,6 @@ mapping.setUserSubtree(parsed_args.user_subtree)
 mapping.setGroupSubtree(parsed_args.group_subtree)
 
 ldapConfig.setMapping(mapping)
-
 
 if (update) {
     ldapConfigMgr.updateLdapServerConfiguration(ldapConfig)


### PR DESCRIPTION
Related to: INFRA-1251
Changes copied from upstream and tested on stage on camunda-ci-v2 (rolled back because ArgoCD, but should be tested on stage again)

Those 3 files didn't work during the initial test. All 3 files had issue like:
```
You cannot create an instance from the abstract interface xyz
```
The issue is mentioned here for LDAP file but it was the same for the rest:
https://github.com/ansible-ThoTeam/nexus3-oss/issues/258

I copied only those files to minimize the effect of the change.
Maybe it's a good idea to create another ticket to upgrade the whole Ansible role.