### PR TITLE
Rebase on v2.4.15

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ nexus_version: ''
 # /!\ It should never be set directly /!\
 # nexus_version_running: <unset>
 
+nexus_install_enable: true
 nexus_download_dir: '/tmp'
 nexus_download_url: 'https://download.sonatype.com/nexus/3'
 nexus_os_group: 'nexus'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,7 +60,7 @@
     - nuget-group
     - nuget-hosted
     - nuget.org-proxy
-  when: (nexus_data_dir_contents.stdout | length == 0) and nexus_delete_default_repos
+  when: nexus_delete_default_repos # and (nexus_data_dir_contents.stdout | length == 0)
 
 - name: Deleting default blobstore
   include_tasks: delete_blobstore_each.yml
@@ -72,7 +72,7 @@
       | list
       | unique
     }}
-  when: (nexus_data_dir_contents.stdout | length == 0) and nexus_delete_default_blobstore
+  when: nexus_delete_default_blobstore # and (nexus_data_dir_contents.stdout | length == 0)
 
 - block:
     - include_tasks: setup_ldap_each.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,15 +5,17 @@
 
 - name: Include OS specific variables.
   include_vars: "configure-{{ ansible_os_family }}.yml"
+  when: nexus_install_enable
 
 - name: Include OS specific selinux libs and utils if needed
   include_tasks: "selinux-{{ ansible_os_family }}.yml"
-  when: ansible_selinux.status is defined and ansible_selinux.status == "enabled"
+  when: ansible_selinux.status is defined and ansible_selinux.status == "enabled" and nexus_install_enable
 
 - name: Check if SystemD service is installed
   stat:
     path: /etc/systemd/system/nexus.service
   register: nexus_systemd_service_file
+  when: nexus_install_enable
 
 - name: Check if sysv service is installed
   stat:
@@ -60,7 +62,7 @@
     - nuget-group
     - nuget-hosted
     - nuget.org-proxy
-  when: nexus_delete_default_repos # and (nexus_data_dir_contents.stdout | length == 0)
+  when: nexus_delete_default_repos  # and (nexus_data_dir_contents.stdout | length == 0)
 
 - name: Deleting default blobstore
   include_tasks: delete_blobstore_each.yml
@@ -72,7 +74,7 @@
       | list
       | unique
     }}
-  when: nexus_delete_default_blobstore # and (nexus_data_dir_contents.stdout | length == 0)
+  when: nexus_delete_default_blobstore  # and (nexus_data_dir_contents.stdout | length == 0)
 
 - block:
     - include_tasks: setup_ldap_each.yml
@@ -107,7 +109,7 @@
             group: "{{ nexus_os_group }}"
             state: directory
             recurse: "{{ nexus_blobstores_recurse_owner | default(false) | bool }}"
-          when: item.path is defined
+          when: item.path is defined and nexus_install_enable
           loop: "{{ nexus_blobstores }}"
 
         - name: Create/Check blobstores
@@ -122,7 +124,7 @@
 
 - name: "Restore nexus backup"
   include_tasks: nexus-restore.yml
-  when: nexus_restore_point is defined
+  when: nexus_restore_point is defined and nexus_install_enable
 
 - block:
     - name: Create/check cleanup policies

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -386,16 +386,15 @@
   when: (nexus_backup_configure | bool) and nexus_install_enable
 
 - name: 'Check if data directory is empty (first-time install)'
-  command: "ls --ignore=lost+found {{ nexus_data_dir }}"
+  find: paths={{ nexus_data_dir }} excludes='lost+found'
   register: nexus_data_dir_contents
-  check_mode: no
   changed_when: false
 
 - name: Clean cache for upgrade process
   file:
     path: "{{ nexus_data_dir }}/clean_cache"
     state: touch
-  when: (nexus_latest_version.changed and nexus_data_dir_contents.stdout | length > 0) and nexus_install_enable
+  when: (nexus_latest_version.changed and nexus_data_dir_contents.matched | int > 0) and nexus_install_enable
   tags:
     # hard to run as a handler for time being
     - skip_ansible_lint

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -68,6 +68,7 @@
 - name: Register nexus package name
   set_fact:
     nexus_package: "nexus-{{ nexus_version }}-unix.tar.gz"
+  when: nexus_install_enable
 
 - name: Download nexus_package
   get_url:
@@ -77,11 +78,13 @@
     validate_certs: "{{ nexus_download_ssl_verify | default(omit) }}"
   notify:
     - nexus-service-stop
+  when: nexus_install_enable
 
 - name: Ensure Nexus o/s group exists
   group:
     name: "{{ nexus_os_group }}"
     state: present
+  when: nexus_install_enable
 
 - name: Ensure Nexus o/s user exists
   user:
@@ -90,12 +93,14 @@
     home: "{{ nexus_os_user_home_dir }}"
     shell: "/bin/bash"
     state: present
+  when: nexus_install_enable
 
 - name: Ensure Nexus installation directory exists
   file:
     path: "{{ nexus_installation_dir }}"
     state: "directory"
     mode: 0755
+  when: nexus_install_enable
 
 - name: Unpack Nexus download
   unarchive:
@@ -106,12 +111,14 @@
     mode: 0755
   notify:
     - nexus-service-stop
+  when: nexus_install_enable
 
 - name: Ensure proper ownership of nexus installation directory
   file:
     path: "{{ nexus_installation_dir }}/nexus-{{ nexus_version }}"
     recurse: yes
     mode: "u=rwX,g=rX,o=rX"
+  when: nexus_install_enable
 
 - name: Update symlink nexus-latest
   file:
@@ -124,29 +131,32 @@
   register: nexus_latest_version
   notify:
     - nexus-service-stop
+  when: nexus_install_enable
 
 - meta: flush_handlers
+  when: nexus_install_enable
 
 - name: Delete unpacked data directory
   file:
     path: "{{ nexus_installation_dir }}/nexus-latest/data"
     state: absent
+  when: nexus_install_enable
 
 - name: Get path to default settings
   set_fact:
     nexus_default_settings_file: "{{ nexus_installation_dir }}/nexus-latest/etc/org.sonatype.nexus.cfg"
-  when: nexus_version is version_compare('3.1.0', '<')
+  when: nexus_version is version_compare('3.1.0', '<') and nexus_install_enable
 
 - name: Get path to default settings
   set_fact:
     nexus_default_settings_file: "{{ nexus_installation_dir }}/nexus-latest/etc/nexus-default.properties"
-  when: nexus_version is version_compare('3.1.0', '>=')
+  when: nexus_version is version_compare('3.1.0', '>=') and nexus_install_enable
 
 - name: Get application settings directories
   set_fact:
     nexus_app_dir_settings_dirs:
       - "{{ nexus_installation_dir }}/nexus-latest/etc"
-  when: nexus_version is version_compare('3.1.0', '<')
+  when: nexus_version is version_compare('3.1.0', '<') and nexus_install_enable
 
 - name: Get application settings directories
   set_fact:
@@ -157,7 +167,7 @@
       - "{{ nexus_installation_dir }}/nexus-latest/etc/fabric"
       - "{{ nexus_installation_dir }}/nexus-latest/etc/logback"
       - "{{ nexus_installation_dir }}/nexus-latest/etc/scripts"
-  when: nexus_version is version_compare('3.1.0', '>=')
+  when: nexus_version is version_compare('3.1.0', '>=') and nexus_install_enable
 
 - name: Get rest API endpoint (v < 3.8.0)
   set_fact:
@@ -172,12 +182,12 @@
 - name: Get path to database restore dir (v < 3.11.0)
   set_fact:
     nexus_db_restore_dir: "{{ nexus_data_dir }}/backup"
-  when: nexus_version is version_compare('3.11.0', '<')
+  when: nexus_version is version_compare('3.11.0', '<') and nexus_install_enable
 
 - name: Get path to database restore dir (v >= 3.11.0)
   set_fact:
     nexus_db_restore_dir: "{{ nexus_data_dir }}/restore-from-backup"
-  when: nexus_version is version_compare('3.11.0', '>=')
+  when: nexus_version is version_compare('3.11.0', '>=') and nexus_install_enable
 
 - name: Allow nexus to create first-time install configuration files in  {{ nexus_installation_dir }}/nexus-latest/etc
   file:
@@ -188,7 +198,7 @@
     mode: "0755"
     recurse: false
   with_items: "{{ nexus_app_dir_settings_dirs }}"
-  when: nexus_latest_version.changed
+  when: nexus_latest_version.changed and nexus_install_enable
   register: chown_config_first_time
   tags:
     # hard to run as a handler for time being
@@ -201,6 +211,7 @@
     owner: "{{ nexus_os_user }}"
     group: "{{ nexus_os_group }}"
     mode: 0750
+  when: nexus_install_enable
 
 - name: Setup Nexus data directory
   lineinfile:
@@ -209,6 +220,7 @@
     line: "-Dkaraf.data={{ nexus_data_dir }}"
   notify:
     - nexus-service-stop
+  when: nexus_install_enable
 
 - name: Setup JVM logfile directory
   lineinfile:
@@ -217,6 +229,7 @@
     line: "-XX:LogFile={{ nexus_data_dir }}/log/jvm.log"
   notify:
     - nexus-service-stop
+  when: nexus_install_enable
 
 - name: Setup Nexus default timezone
   lineinfile:
@@ -225,6 +238,7 @@
     line: "-Duser.timezone={{ nexus_timezone }}"
   notify:
     - nexus-service-stop
+  when: nexus_install_enable
 
 - name: Setup Nexus JVM min heap size
   lineinfile:
@@ -232,6 +246,7 @@
     regexp: "^-Xms.*"
     line: "-Xms{{ nexus_min_heap_size }}"
   notify: nexus-service-stop
+  when: nexus_install_enable
 
 - name: Setup Nexus JVM max heap size
   lineinfile:
@@ -239,6 +254,7 @@
     regexp: "^-Xmx.*"
     line: "-Xmx{{ nexus_max_heap_size }}"
   notify: nexus-service-stop
+  when: nexus_install_enable
 
 - name: Setup Nexus JVM max direct memory
   lineinfile:
@@ -246,6 +262,7 @@
     regexp: "^-XX:MaxDirectMemorySize=.*"
     line: "-XX:MaxDirectMemorySize={{ nexus_max_direct_memory }}"
   notify: nexus-service-stop
+  when: nexus_install_enable
 
 - name: Stop the admin wizard from running
   lineinfile:
@@ -262,6 +279,7 @@
     owner: "{{ nexus_os_user }}"
     group: "{{ nexus_os_group }}"
     mode: 0750
+  when: nexus_install_enable
 
 - name: Create Nexus backup directory
   file:
@@ -270,7 +288,7 @@
     owner: "{{ nexus_os_user }}"
     group: "{{ nexus_os_group }}"
     mode: 0750
-  when: nexus_backup_dir_create | bool
+  when: ( nexus_backup_dir_create | bool ) and nexus_install_enable
 
 - name: Setup Nexus tmp directory
   lineinfile:
@@ -279,6 +297,7 @@
     line: "-Djava.io.tmpdir={{ nexus_tmp_dir }}"
   notify:
     - nexus-service-stop
+  when: nexus_install_enable
 
 - name: Set NEXUS_HOME for the service user
   lineinfile:
@@ -287,6 +306,7 @@
     line: "export NEXUS_HOME={{ nexus_installation_dir }}/nexus-latest"
   notify:
     - nexus-service-stop
+  when: nexus_install_enable
 
 - name: Set nexus user
   lineinfile:
@@ -295,6 +315,7 @@
     line: "run_as_user=\"{{ nexus_os_user }}\""
   notify:
     - nexus-service-stop
+  when: nexus_install_enable
 
 - name: Set nexus port
   lineinfile:
@@ -303,6 +324,7 @@
     line: "application-port={{ nexus_default_port }}"
   notify:
     - nexus-service-stop
+  when: nexus_install_enable
 
 - name: Set nexus context path
   lineinfile:
@@ -311,6 +333,7 @@
     line: "nexus-context-path={{ nexus_default_context_path }}"
   notify:
     - nexus-service-stop
+  when: nexus_install_enable
 
 - name: "Set nexus service listening ip to {{ nexus_application_host }}"
   lineinfile:
@@ -319,6 +342,7 @@
     line: "application-host={{ nexus_application_host }}"
   notify:
     - nexus-service-stop
+  when: (httpd_setup_enable | bool) and nexus_install_enable
 
 # Note: this one is mandatory until we move all our groovy scripts
 # to REST API calls. Once this is done, we will move this to an
@@ -330,7 +354,7 @@
     line: "nexus.scripts.allowCreation=true"
   notify:
     - nexus-service-stop
-  when: nexus_version is version_compare('3.21.2', '>=')
+  when: nexus_version is version_compare('3.21.2', '>=') and nexus_install_enable
 
 - name: Create systemd service configuration
   template:
@@ -339,14 +363,14 @@
     mode: 0644
   notify:
     - systemd-reload
-  when: "ansible_service_mgr == 'systemd'"
+  when: "ansible_service_mgr == 'systemd' and nexus_install_enable | bool"
 
 - name: Create sysv service configuration
   file:
     path: "/etc/init.d/nexus"
     src: "{{ nexus_installation_dir }}/nexus-latest/bin/nexus"
     state: link
-  when: "ansible_service_mgr != 'systemd'"
+  when: "ansible_service_mgr != 'systemd' and nexus_install_enable | bool"
 
 - block:
     - name: "Deploy backup restore script"
@@ -359,7 +383,7 @@
         src: "{{ nexus_script_dir }}/nexus-blob-restore.sh"
         dest: "/sbin/nexus-blob-restore.sh"
         state: link
-  when: nexus_backup_configure | bool
+  when: (nexus_backup_configure | bool) and nexus_install_enable
 
 - name: 'Check if data directory is empty (first-time install)'
   command: "ls --ignore=lost+found {{ nexus_data_dir }}"
@@ -371,12 +395,13 @@
   file:
     path: "{{ nexus_data_dir }}/clean_cache"
     state: touch
-  when: nexus_latest_version.changed and nexus_data_dir_contents.stdout | length > 0
+  when: (nexus_latest_version.changed and nexus_data_dir_contents.stdout | length > 0) and nexus_install_enable
   tags:
     # hard to run as a handler for time being
     - skip_ansible_lint
 
 - meta: flush_handlers
+  when: nexus_install_enable
 
 - name: Enable nexus systemd service and make sure it is started
   systemd:
@@ -387,7 +412,7 @@
   notify:
     - wait-for-nexus
     - wait-for-nexus-port
-  when: "ansible_service_mgr == 'systemd'"
+  when: "ansible_service_mgr == 'systemd' and nexus_install_enable | bool"
 
 - name: Enable nexus sysv service and make sure it is started
   service:
@@ -397,9 +422,10 @@
   notify:
     - wait-for-nexus
     - wait-for-nexus-port
-  when: "ansible_service_mgr != 'systemd'"
+  when: "ansible_service_mgr != 'systemd' and nexus_install_enable | bool"
 
 - meta: flush_handlers
+  when: nexus_install_enable
 
 - name: Chown configuration files from {{ nexus_installation_dir }}/nexus-latest/etc back to root
   file:
@@ -408,7 +434,7 @@
     group: "root"
     mode: a=rX,u+w
     recurse: true
-  when: chown_config_first_time.changed
+  when: chown_config_first_time.changed and nexus_install_enable
   tags:
     # hard to run as a handler for time being
     - skip_ansible_lint
@@ -422,6 +448,7 @@
     mode: "0755"
     recurse: false
   with_items: "{{ nexus_app_dir_settings_dirs }}"
+  when: nexus_install_enable
 
 - name: Install plugins from remote source
   get_url:

--- a/tasks/nexus_install.yml
+++ b/tasks/nexus_install.yml
@@ -270,7 +270,7 @@
     line: "nexus.onboarding.enabled={{ nexus_onboarding_wizard }}"
     create: true
     mode: 0644
-  when: nexus_version is version_compare('3.17.0', '>=')
+  when: nexus_version is version_compare('3.1.0', '>=') and nexus_install_enable
 
 - name: Create Nexus tmp directory
   file:


### PR DESCRIPTION
Prerequisite of [INFRA-2143](https://jira.camunda.com/browse/INFRA-2143).

I've rebased `camunda2` on master@upstream, this is the result.

Our commits - some I could drop because upstream implemented the change in the meantime:
- Fix authentication for created proxy repos
- chore(main.yml): always delete default repos and blobstore if flag is present
- chore(config): allow to skip Nexus installation

Merging instructions:
- [x] backup `camunda2` as `camunda-2.4.3`
- [x] change base to `camunda2`
- [x] merge 
